### PR TITLE
Create structures for decoding launch library2 api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Structures for decoding responses from the LaunchLibrary2 API.
+
 ### Changed
 
 - The project file structure according to the clean approach.

--- a/SpaceLaunches.xcodeproj/project.pbxproj
+++ b/SpaceLaunches.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		746C1F402B10F9F600FA9612 /* OrbitResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F3F2B10F9F600FA9612 /* OrbitResponse.swift */; };
 		746C1F422B10FA1C00FA9612 /* AgencyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F412B10FA1C00FA9612 /* AgencyResponse.swift */; };
 		746C1F442B10FA3700FA9612 /* PadResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F432B10FA3700FA9612 /* PadResponse.swift */; };
+		746C1F462B10FA5600FA9612 /* LocationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F452B10FA5600FA9612 /* LocationResponse.swift */; };
 		7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0172B0CA804008AA32B /* AppDelegate.swift */; };
 		7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0192B0CA804008AA32B /* SceneDelegate.swift */; };
 		7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E01B2B0CA804008AA32B /* ViewController.swift */; };
@@ -39,6 +40,7 @@
 		746C1F3F2B10F9F600FA9612 /* OrbitResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrbitResponse.swift; sourceTree = "<group>"; };
 		746C1F412B10FA1C00FA9612 /* AgencyResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgencyResponse.swift; sourceTree = "<group>"; };
 		746C1F432B10FA3700FA9612 /* PadResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PadResponse.swift; sourceTree = "<group>"; };
+		746C1F452B10FA5600FA9612 /* LocationResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationResponse.swift; sourceTree = "<group>"; };
 		7474E0142B0CA804008AA32B /* SpaceLaunches.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpaceLaunches.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7474E0172B0CA804008AA32B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7474E0192B0CA804008AA32B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -146,6 +148,7 @@
 				746C1F3F2B10F9F600FA9612 /* OrbitResponse.swift */,
 				746C1F412B10FA1C00FA9612 /* AgencyResponse.swift */,
 				746C1F432B10FA3700FA9612 /* PadResponse.swift */,
+				746C1F452B10FA5600FA9612 /* LocationResponse.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -326,6 +329,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */,
+				746C1F462B10FA5600FA9612 /* LocationResponse.swift in Sources */,
 				746C1F362B10F93F00FA9612 /* LaunchStatusResponse.swift in Sources */,
 				746C1F322B10F89000FA9612 /* LaunchListResponse.swift in Sources */,
 				746C1F3C2B10F9AD00FA9612 /* RocketConfigurationResponse.swift in Sources */,

--- a/SpaceLaunches.xcodeproj/project.pbxproj
+++ b/SpaceLaunches.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F332B10F8BA00FA9612 /* LaunchResponse.swift */; };
 		746C1F362B10F93F00FA9612 /* LaunchStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F352B10F93F00FA9612 /* LaunchStatusResponse.swift */; };
 		746C1F382B10F97500FA9612 /* LaunchServiceProviderResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F372B10F97500FA9612 /* LaunchServiceProviderResponse.swift */; };
+		746C1F3A2B10F99000FA9612 /* RocketResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F392B10F99000FA9612 /* RocketResponse.swift */; };
 		7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0172B0CA804008AA32B /* AppDelegate.swift */; };
 		7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0192B0CA804008AA32B /* SceneDelegate.swift */; };
 		7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E01B2B0CA804008AA32B /* ViewController.swift */; };
@@ -27,6 +28,7 @@
 		746C1F332B10F8BA00FA9612 /* LaunchResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchResponse.swift; sourceTree = "<group>"; };
 		746C1F352B10F93F00FA9612 /* LaunchStatusResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchStatusResponse.swift; sourceTree = "<group>"; };
 		746C1F372B10F97500FA9612 /* LaunchServiceProviderResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchServiceProviderResponse.swift; sourceTree = "<group>"; };
+		746C1F392B10F99000FA9612 /* RocketResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketResponse.swift; sourceTree = "<group>"; };
 		7474E0142B0CA804008AA32B /* SpaceLaunches.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpaceLaunches.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7474E0172B0CA804008AA32B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7474E0192B0CA804008AA32B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -128,6 +130,7 @@
 				746C1F332B10F8BA00FA9612 /* LaunchResponse.swift */,
 				746C1F352B10F93F00FA9612 /* LaunchStatusResponse.swift */,
 				746C1F372B10F97500FA9612 /* LaunchServiceProviderResponse.swift */,
+				746C1F392B10F99000FA9612 /* RocketResponse.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -313,6 +316,7 @@
 				746C1F382B10F97500FA9612 /* LaunchServiceProviderResponse.swift in Sources */,
 				7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */,
 				746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */,
+				746C1F3A2B10F99000FA9612 /* RocketResponse.swift in Sources */,
 				7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SpaceLaunches.xcodeproj/project.pbxproj
+++ b/SpaceLaunches.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		746C1F362B10F93F00FA9612 /* LaunchStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F352B10F93F00FA9612 /* LaunchStatusResponse.swift */; };
 		746C1F382B10F97500FA9612 /* LaunchServiceProviderResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F372B10F97500FA9612 /* LaunchServiceProviderResponse.swift */; };
 		746C1F3A2B10F99000FA9612 /* RocketResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F392B10F99000FA9612 /* RocketResponse.swift */; };
+		746C1F3C2B10F9AD00FA9612 /* RocketConfigurationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F3B2B10F9AD00FA9612 /* RocketConfigurationResponse.swift */; };
 		7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0172B0CA804008AA32B /* AppDelegate.swift */; };
 		7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0192B0CA804008AA32B /* SceneDelegate.swift */; };
 		7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E01B2B0CA804008AA32B /* ViewController.swift */; };
@@ -29,6 +30,7 @@
 		746C1F352B10F93F00FA9612 /* LaunchStatusResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchStatusResponse.swift; sourceTree = "<group>"; };
 		746C1F372B10F97500FA9612 /* LaunchServiceProviderResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchServiceProviderResponse.swift; sourceTree = "<group>"; };
 		746C1F392B10F99000FA9612 /* RocketResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketResponse.swift; sourceTree = "<group>"; };
+		746C1F3B2B10F9AD00FA9612 /* RocketConfigurationResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketConfigurationResponse.swift; sourceTree = "<group>"; };
 		7474E0142B0CA804008AA32B /* SpaceLaunches.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpaceLaunches.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7474E0172B0CA804008AA32B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7474E0192B0CA804008AA32B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -131,6 +133,7 @@
 				746C1F352B10F93F00FA9612 /* LaunchStatusResponse.swift */,
 				746C1F372B10F97500FA9612 /* LaunchServiceProviderResponse.swift */,
 				746C1F392B10F99000FA9612 /* RocketResponse.swift */,
+				746C1F3B2B10F9AD00FA9612 /* RocketConfigurationResponse.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -313,6 +316,7 @@
 				7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */,
 				746C1F362B10F93F00FA9612 /* LaunchStatusResponse.swift in Sources */,
 				746C1F322B10F89000FA9612 /* LaunchListResponse.swift in Sources */,
+				746C1F3C2B10F9AD00FA9612 /* RocketConfigurationResponse.swift in Sources */,
 				746C1F382B10F97500FA9612 /* LaunchServiceProviderResponse.swift in Sources */,
 				7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */,
 				746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */,

--- a/SpaceLaunches.xcodeproj/project.pbxproj
+++ b/SpaceLaunches.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		746C1F322B10F89000FA9612 /* LaunchListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F312B10F89000FA9612 /* LaunchListResponse.swift */; };
 		746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F332B10F8BA00FA9612 /* LaunchResponse.swift */; };
 		746C1F362B10F93F00FA9612 /* LaunchStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F352B10F93F00FA9612 /* LaunchStatusResponse.swift */; };
+		746C1F382B10F97500FA9612 /* LaunchServiceProviderResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F372B10F97500FA9612 /* LaunchServiceProviderResponse.swift */; };
 		7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0172B0CA804008AA32B /* AppDelegate.swift */; };
 		7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0192B0CA804008AA32B /* SceneDelegate.swift */; };
 		7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E01B2B0CA804008AA32B /* ViewController.swift */; };
@@ -25,6 +26,7 @@
 		746C1F312B10F89000FA9612 /* LaunchListResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchListResponse.swift; sourceTree = "<group>"; };
 		746C1F332B10F8BA00FA9612 /* LaunchResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchResponse.swift; sourceTree = "<group>"; };
 		746C1F352B10F93F00FA9612 /* LaunchStatusResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchStatusResponse.swift; sourceTree = "<group>"; };
+		746C1F372B10F97500FA9612 /* LaunchServiceProviderResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchServiceProviderResponse.swift; sourceTree = "<group>"; };
 		7474E0142B0CA804008AA32B /* SpaceLaunches.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpaceLaunches.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7474E0172B0CA804008AA32B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7474E0192B0CA804008AA32B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 				746C1F312B10F89000FA9612 /* LaunchListResponse.swift */,
 				746C1F332B10F8BA00FA9612 /* LaunchResponse.swift */,
 				746C1F352B10F93F00FA9612 /* LaunchStatusResponse.swift */,
+				746C1F372B10F97500FA9612 /* LaunchServiceProviderResponse.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -307,6 +310,7 @@
 				7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */,
 				746C1F362B10F93F00FA9612 /* LaunchStatusResponse.swift in Sources */,
 				746C1F322B10F89000FA9612 /* LaunchListResponse.swift in Sources */,
+				746C1F382B10F97500FA9612 /* LaunchServiceProviderResponse.swift in Sources */,
 				7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */,
 				746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */,
 				7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */,

--- a/SpaceLaunches.xcodeproj/project.pbxproj
+++ b/SpaceLaunches.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		746C1F3C2B10F9AD00FA9612 /* RocketConfigurationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F3B2B10F9AD00FA9612 /* RocketConfigurationResponse.swift */; };
 		746C1F3E2B10F9D500FA9612 /* MissionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F3D2B10F9D500FA9612 /* MissionResponse.swift */; };
 		746C1F402B10F9F600FA9612 /* OrbitResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F3F2B10F9F600FA9612 /* OrbitResponse.swift */; };
+		746C1F422B10FA1C00FA9612 /* AgencyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F412B10FA1C00FA9612 /* AgencyResponse.swift */; };
 		7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0172B0CA804008AA32B /* AppDelegate.swift */; };
 		7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0192B0CA804008AA32B /* SceneDelegate.swift */; };
 		7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E01B2B0CA804008AA32B /* ViewController.swift */; };
@@ -35,6 +36,7 @@
 		746C1F3B2B10F9AD00FA9612 /* RocketConfigurationResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketConfigurationResponse.swift; sourceTree = "<group>"; };
 		746C1F3D2B10F9D500FA9612 /* MissionResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MissionResponse.swift; sourceTree = "<group>"; };
 		746C1F3F2B10F9F600FA9612 /* OrbitResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrbitResponse.swift; sourceTree = "<group>"; };
+		746C1F412B10FA1C00FA9612 /* AgencyResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgencyResponse.swift; sourceTree = "<group>"; };
 		7474E0142B0CA804008AA32B /* SpaceLaunches.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpaceLaunches.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7474E0172B0CA804008AA32B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7474E0192B0CA804008AA32B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -140,6 +142,7 @@
 				746C1F3B2B10F9AD00FA9612 /* RocketConfigurationResponse.swift */,
 				746C1F3D2B10F9D500FA9612 /* MissionResponse.swift */,
 				746C1F3F2B10F9F600FA9612 /* OrbitResponse.swift */,
+				746C1F412B10FA1C00FA9612 /* AgencyResponse.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -328,6 +331,7 @@
 				7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */,
 				746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */,
 				746C1F3A2B10F99000FA9612 /* RocketResponse.swift in Sources */,
+				746C1F422B10FA1C00FA9612 /* AgencyResponse.swift in Sources */,
 				746C1F402B10F9F600FA9612 /* OrbitResponse.swift in Sources */,
 				7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */,
 			);

--- a/SpaceLaunches.xcodeproj/project.pbxproj
+++ b/SpaceLaunches.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		746C1F322B10F89000FA9612 /* LaunchListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F312B10F89000FA9612 /* LaunchListResponse.swift */; };
 		7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0172B0CA804008AA32B /* AppDelegate.swift */; };
 		7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0192B0CA804008AA32B /* SceneDelegate.swift */; };
 		7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E01B2B0CA804008AA32B /* ViewController.swift */; };
@@ -19,6 +20,7 @@
 		208D79752BB5E4BA155BB8E5 /* Pods-SpaceLaunches.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SpaceLaunches.debug.xcconfig"; path = "Target Support Files/Pods-SpaceLaunches/Pods-SpaceLaunches.debug.xcconfig"; sourceTree = "<group>"; };
 		593C047467B9CBB825EE2664 /* Pods_SpaceLaunches.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SpaceLaunches.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		658D6344A47DA3F975424A99 /* Pods-SpaceLaunches.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SpaceLaunches.release.xcconfig"; path = "Target Support Files/Pods-SpaceLaunches/Pods-SpaceLaunches.release.xcconfig"; sourceTree = "<group>"; };
+		746C1F312B10F89000FA9612 /* LaunchListResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchListResponse.swift; sourceTree = "<group>"; };
 		7474E0142B0CA804008AA32B /* SpaceLaunches.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpaceLaunches.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7474E0172B0CA804008AA32B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7474E0192B0CA804008AA32B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -61,6 +63,7 @@
 		741FB9F22B0F8EDF00E6A95E /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				746C1F172B10B62C00FA9612 /* Network */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -94,6 +97,30 @@
 			children = (
 			);
 			path = Common;
+			sourceTree = "<group>";
+		};
+		746C1F172B10B62C00FA9612 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				746C1F182B10B6AA00FA9612 /* LaunchLibrary2 */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		746C1F182B10B6AA00FA9612 /* LaunchLibrary2 */ = {
+			isa = PBXGroup;
+			children = (
+				746C1F192B10BA0000FA9612 /* Entities */,
+			);
+			path = LaunchLibrary2;
+			sourceTree = "<group>";
+		};
+		746C1F192B10BA0000FA9612 /* Entities */ = {
+			isa = PBXGroup;
+			children = (
+				746C1F312B10F89000FA9612 /* LaunchListResponse.swift */,
+			);
+			path = Entities;
 			sourceTree = "<group>";
 		};
 		7474E00B2B0CA803008AA32B = {
@@ -272,6 +299,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */,
+				746C1F322B10F89000FA9612 /* LaunchListResponse.swift in Sources */,
 				7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */,
 				7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */,
 			);

--- a/SpaceLaunches.xcodeproj/project.pbxproj
+++ b/SpaceLaunches.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		746C1F322B10F89000FA9612 /* LaunchListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F312B10F89000FA9612 /* LaunchListResponse.swift */; };
 		746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F332B10F8BA00FA9612 /* LaunchResponse.swift */; };
+		746C1F362B10F93F00FA9612 /* LaunchStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F352B10F93F00FA9612 /* LaunchStatusResponse.swift */; };
 		7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0172B0CA804008AA32B /* AppDelegate.swift */; };
 		7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0192B0CA804008AA32B /* SceneDelegate.swift */; };
 		7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E01B2B0CA804008AA32B /* ViewController.swift */; };
@@ -23,6 +24,7 @@
 		658D6344A47DA3F975424A99 /* Pods-SpaceLaunches.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SpaceLaunches.release.xcconfig"; path = "Target Support Files/Pods-SpaceLaunches/Pods-SpaceLaunches.release.xcconfig"; sourceTree = "<group>"; };
 		746C1F312B10F89000FA9612 /* LaunchListResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchListResponse.swift; sourceTree = "<group>"; };
 		746C1F332B10F8BA00FA9612 /* LaunchResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchResponse.swift; sourceTree = "<group>"; };
+		746C1F352B10F93F00FA9612 /* LaunchStatusResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchStatusResponse.swift; sourceTree = "<group>"; };
 		7474E0142B0CA804008AA32B /* SpaceLaunches.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpaceLaunches.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7474E0172B0CA804008AA32B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7474E0192B0CA804008AA32B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 			children = (
 				746C1F312B10F89000FA9612 /* LaunchListResponse.swift */,
 				746C1F332B10F8BA00FA9612 /* LaunchResponse.swift */,
+				746C1F352B10F93F00FA9612 /* LaunchStatusResponse.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -302,6 +305,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */,
+				746C1F362B10F93F00FA9612 /* LaunchStatusResponse.swift in Sources */,
 				746C1F322B10F89000FA9612 /* LaunchListResponse.swift in Sources */,
 				7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */,
 				746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */,

--- a/SpaceLaunches.xcodeproj/project.pbxproj
+++ b/SpaceLaunches.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		746C1F3A2B10F99000FA9612 /* RocketResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F392B10F99000FA9612 /* RocketResponse.swift */; };
 		746C1F3C2B10F9AD00FA9612 /* RocketConfigurationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F3B2B10F9AD00FA9612 /* RocketConfigurationResponse.swift */; };
 		746C1F3E2B10F9D500FA9612 /* MissionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F3D2B10F9D500FA9612 /* MissionResponse.swift */; };
+		746C1F402B10F9F600FA9612 /* OrbitResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F3F2B10F9F600FA9612 /* OrbitResponse.swift */; };
 		7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0172B0CA804008AA32B /* AppDelegate.swift */; };
 		7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0192B0CA804008AA32B /* SceneDelegate.swift */; };
 		7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E01B2B0CA804008AA32B /* ViewController.swift */; };
@@ -33,6 +34,7 @@
 		746C1F392B10F99000FA9612 /* RocketResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketResponse.swift; sourceTree = "<group>"; };
 		746C1F3B2B10F9AD00FA9612 /* RocketConfigurationResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketConfigurationResponse.swift; sourceTree = "<group>"; };
 		746C1F3D2B10F9D500FA9612 /* MissionResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MissionResponse.swift; sourceTree = "<group>"; };
+		746C1F3F2B10F9F600FA9612 /* OrbitResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrbitResponse.swift; sourceTree = "<group>"; };
 		7474E0142B0CA804008AA32B /* SpaceLaunches.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpaceLaunches.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7474E0172B0CA804008AA32B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7474E0192B0CA804008AA32B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -137,6 +139,7 @@
 				746C1F392B10F99000FA9612 /* RocketResponse.swift */,
 				746C1F3B2B10F9AD00FA9612 /* RocketConfigurationResponse.swift */,
 				746C1F3D2B10F9D500FA9612 /* MissionResponse.swift */,
+				746C1F3F2B10F9F600FA9612 /* OrbitResponse.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -325,6 +328,7 @@
 				7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */,
 				746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */,
 				746C1F3A2B10F99000FA9612 /* RocketResponse.swift in Sources */,
+				746C1F402B10F9F600FA9612 /* OrbitResponse.swift in Sources */,
 				7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SpaceLaunches.xcodeproj/project.pbxproj
+++ b/SpaceLaunches.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		746C1F382B10F97500FA9612 /* LaunchServiceProviderResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F372B10F97500FA9612 /* LaunchServiceProviderResponse.swift */; };
 		746C1F3A2B10F99000FA9612 /* RocketResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F392B10F99000FA9612 /* RocketResponse.swift */; };
 		746C1F3C2B10F9AD00FA9612 /* RocketConfigurationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F3B2B10F9AD00FA9612 /* RocketConfigurationResponse.swift */; };
+		746C1F3E2B10F9D500FA9612 /* MissionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F3D2B10F9D500FA9612 /* MissionResponse.swift */; };
 		7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0172B0CA804008AA32B /* AppDelegate.swift */; };
 		7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0192B0CA804008AA32B /* SceneDelegate.swift */; };
 		7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E01B2B0CA804008AA32B /* ViewController.swift */; };
@@ -31,6 +32,7 @@
 		746C1F372B10F97500FA9612 /* LaunchServiceProviderResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchServiceProviderResponse.swift; sourceTree = "<group>"; };
 		746C1F392B10F99000FA9612 /* RocketResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketResponse.swift; sourceTree = "<group>"; };
 		746C1F3B2B10F9AD00FA9612 /* RocketConfigurationResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketConfigurationResponse.swift; sourceTree = "<group>"; };
+		746C1F3D2B10F9D500FA9612 /* MissionResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MissionResponse.swift; sourceTree = "<group>"; };
 		7474E0142B0CA804008AA32B /* SpaceLaunches.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpaceLaunches.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7474E0172B0CA804008AA32B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7474E0192B0CA804008AA32B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -134,6 +136,7 @@
 				746C1F372B10F97500FA9612 /* LaunchServiceProviderResponse.swift */,
 				746C1F392B10F99000FA9612 /* RocketResponse.swift */,
 				746C1F3B2B10F9AD00FA9612 /* RocketConfigurationResponse.swift */,
+				746C1F3D2B10F9D500FA9612 /* MissionResponse.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -318,6 +321,7 @@
 				746C1F322B10F89000FA9612 /* LaunchListResponse.swift in Sources */,
 				746C1F3C2B10F9AD00FA9612 /* RocketConfigurationResponse.swift in Sources */,
 				746C1F382B10F97500FA9612 /* LaunchServiceProviderResponse.swift in Sources */,
+				746C1F3E2B10F9D500FA9612 /* MissionResponse.swift in Sources */,
 				7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */,
 				746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */,
 				746C1F3A2B10F99000FA9612 /* RocketResponse.swift in Sources */,

--- a/SpaceLaunches.xcodeproj/project.pbxproj
+++ b/SpaceLaunches.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		746C1F322B10F89000FA9612 /* LaunchListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F312B10F89000FA9612 /* LaunchListResponse.swift */; };
+		746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F332B10F8BA00FA9612 /* LaunchResponse.swift */; };
 		7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0172B0CA804008AA32B /* AppDelegate.swift */; };
 		7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0192B0CA804008AA32B /* SceneDelegate.swift */; };
 		7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E01B2B0CA804008AA32B /* ViewController.swift */; };
@@ -21,6 +22,7 @@
 		593C047467B9CBB825EE2664 /* Pods_SpaceLaunches.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SpaceLaunches.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		658D6344A47DA3F975424A99 /* Pods-SpaceLaunches.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SpaceLaunches.release.xcconfig"; path = "Target Support Files/Pods-SpaceLaunches/Pods-SpaceLaunches.release.xcconfig"; sourceTree = "<group>"; };
 		746C1F312B10F89000FA9612 /* LaunchListResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchListResponse.swift; sourceTree = "<group>"; };
+		746C1F332B10F8BA00FA9612 /* LaunchResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchResponse.swift; sourceTree = "<group>"; };
 		7474E0142B0CA804008AA32B /* SpaceLaunches.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpaceLaunches.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7474E0172B0CA804008AA32B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7474E0192B0CA804008AA32B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 			isa = PBXGroup;
 			children = (
 				746C1F312B10F89000FA9612 /* LaunchListResponse.swift */,
+				746C1F332B10F8BA00FA9612 /* LaunchResponse.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -301,6 +304,7 @@
 				7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */,
 				746C1F322B10F89000FA9612 /* LaunchListResponse.swift in Sources */,
 				7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */,
+				746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */,
 				7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SpaceLaunches.xcodeproj/project.pbxproj
+++ b/SpaceLaunches.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		746C1F3E2B10F9D500FA9612 /* MissionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F3D2B10F9D500FA9612 /* MissionResponse.swift */; };
 		746C1F402B10F9F600FA9612 /* OrbitResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F3F2B10F9F600FA9612 /* OrbitResponse.swift */; };
 		746C1F422B10FA1C00FA9612 /* AgencyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F412B10FA1C00FA9612 /* AgencyResponse.swift */; };
+		746C1F442B10FA3700FA9612 /* PadResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746C1F432B10FA3700FA9612 /* PadResponse.swift */; };
 		7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0172B0CA804008AA32B /* AppDelegate.swift */; };
 		7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E0192B0CA804008AA32B /* SceneDelegate.swift */; };
 		7474E01C2B0CA804008AA32B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7474E01B2B0CA804008AA32B /* ViewController.swift */; };
@@ -37,6 +38,7 @@
 		746C1F3D2B10F9D500FA9612 /* MissionResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MissionResponse.swift; sourceTree = "<group>"; };
 		746C1F3F2B10F9F600FA9612 /* OrbitResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrbitResponse.swift; sourceTree = "<group>"; };
 		746C1F412B10FA1C00FA9612 /* AgencyResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgencyResponse.swift; sourceTree = "<group>"; };
+		746C1F432B10FA3700FA9612 /* PadResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PadResponse.swift; sourceTree = "<group>"; };
 		7474E0142B0CA804008AA32B /* SpaceLaunches.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpaceLaunches.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7474E0172B0CA804008AA32B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7474E0192B0CA804008AA32B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 				746C1F3D2B10F9D500FA9612 /* MissionResponse.swift */,
 				746C1F3F2B10F9F600FA9612 /* OrbitResponse.swift */,
 				746C1F412B10FA1C00FA9612 /* AgencyResponse.swift */,
+				746C1F432B10FA3700FA9612 /* PadResponse.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -331,6 +334,7 @@
 				7474E0182B0CA804008AA32B /* AppDelegate.swift in Sources */,
 				746C1F342B10F8BA00FA9612 /* LaunchResponse.swift in Sources */,
 				746C1F3A2B10F99000FA9612 /* RocketResponse.swift in Sources */,
+				746C1F442B10FA3700FA9612 /* PadResponse.swift in Sources */,
 				746C1F422B10FA1C00FA9612 /* AgencyResponse.swift in Sources */,
 				746C1F402B10F9F600FA9612 /* OrbitResponse.swift in Sources */,
 				7474E01A2B0CA804008AA32B /* SceneDelegate.swift in Sources */,

--- a/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/AgencyResponse.swift
+++ b/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/AgencyResponse.swift
@@ -1,0 +1,16 @@
+/// The response data for the agency information.
+struct AgencyResponse: Codable {
+    /// The unique identifier for the agency.
+    let id: Int
+    /// The name of the agency.
+    let name: String
+    /// The URL for the logo of the agency, if available.
+    let logoURL: String?
+
+    /// Coding keys to map the structure to JSON keys during encoding and decoding.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case logoURL = "logo_url"
+    }
+}

--- a/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/LaunchListResponse.swift
+++ b/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/LaunchListResponse.swift
@@ -1,0 +1,11 @@
+/// Paginated response for the list of launches.
+struct LaunchListResponse: Codable {
+    /// The total count of launches available.
+    let count: Int
+    /// The URL for the next page of launches, if available.
+    let next: String?
+    /// The URL for the previous page of launches, if available.
+    let previous: String?
+    /// Contains `LaunchResponse` objects representing launches in the current response.
+    let results: [LaunchResponse]
+}

--- a/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/LaunchResponse.swift
+++ b/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/LaunchResponse.swift
@@ -1,0 +1,34 @@
+/// The response data for the launch.
+struct LaunchResponse: Codable {
+    /// The unique identifier for the launch.
+    let id: String
+    /// The name of the launch.
+    let name: String
+    /// The status of the launch, if available.
+    let status: LaunchStatusResponse?
+    /// The scheduled launch date and time in ISO 8601 format.
+    let net: String?
+    /// Information about the launch service provider, if available.
+    let launchServiceProvider: LaunchServiceProviderResponse?
+    /// Information about the rocket used in the launch, if available.
+    let rocket: RocketResponse?
+    /// Information about the mission associated with the launch, if available.
+    let mission: MissionResponse?
+    /// Information about the launch pad, if available.
+    let pad: PadResponse?
+    /// The URL to an image related to the launch, if available.
+    let image: String?
+
+    /// Coding keys to map the structure to JSON keys during encoding and decoding.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case status
+        case net
+        case launchServiceProvider = "launch_service_provider"
+        case rocket
+        case mission
+        case pad
+        case image
+    }
+}

--- a/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/LaunchServiceProviderResponse.swift
+++ b/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/LaunchServiceProviderResponse.swift
@@ -1,0 +1,16 @@
+/// The response data for the launch service provider information.
+struct LaunchServiceProviderResponse: Codable {
+    /// The unique identifier for the launch service provider.
+    let id: Int
+    /// The name of the launch service provider.
+    let name: String
+    /// The URL for the logo of the launch service provider, if available.
+    let logoURL: String?
+
+    /// Coding keys to map the structure to JSON keys during encoding and decoding.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case logoURL = "logo_url"
+    }
+}

--- a/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/LaunchStatusResponse.swift
+++ b/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/LaunchStatusResponse.swift
@@ -1,0 +1,19 @@
+/// The response data for the launch status information.
+struct LaunchStatusResponse: Codable {
+    /// The unique identifier for the launch status.
+    let id: Int
+    /// The name of the launch status.
+    let name: String
+    /// The abbreviated representation of the launch status.
+    let abbrev: String
+    /// The description of the launch status.
+    let description: String
+
+    /// Coding keys to map the structure to JSON keys during encoding and decoding.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case abbrev
+        case description
+    }
+}

--- a/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/LocationResponse.swift
+++ b/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/LocationResponse.swift
@@ -1,0 +1,13 @@
+/// The response data for the location information.
+struct LocationResponse: Codable {
+    /// The unique identifier for the location.
+    let id: Int
+    /// The name of the location.
+    let name: String
+
+    /// Coding keys to map the structure to JSON keys during encoding and decoding.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+    }
+}

--- a/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/MissionResponse.swift
+++ b/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/MissionResponse.swift
@@ -1,0 +1,25 @@
+/// The response data for the mission information.
+struct MissionResponse: Codable {
+    /// The unique identifier for the mission.
+    let id: Int
+    /// The name of the mission.
+    let name: String
+    /// The description of the mission.
+    let description: String
+    /// The type of the mission.
+    let type: String
+    /// The orbit details associated with the mission, if available.
+    let orbit: OrbitResponse?
+    /// The agencies involved in the mission, if available.
+    let agencies: [AgencyResponse]?
+
+    /// Coding keys to map the structure to JSON keys during encoding and decoding.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case description
+        case type
+        case orbit
+        case agencies
+    }
+}

--- a/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/OrbitResponse.swift
+++ b/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/OrbitResponse.swift
@@ -1,0 +1,16 @@
+/// The response data for the orbit information.
+struct OrbitResponse: Codable {
+    /// The unique identifier for the orbit.
+    let id: Int
+    /// The name of the orbit.
+    let name: String
+    /// The abbreviated representation of the orbit.
+    let abbrev: String
+
+    /// Coding keys to map the structure to JSON keys during encoding and decoding.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case abbrev
+    }
+}

--- a/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/PadResponse.swift
+++ b/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/PadResponse.swift
@@ -1,0 +1,19 @@
+/// The response data for the pad information.
+struct PadResponse: Codable {
+    /// The unique identifier for the pad.
+    let id: Int
+    /// The latitude of the pad, if available.
+    let latitude: String?
+    /// The longitude of the pad, if available.
+    let longitude: String?
+    /// The location details associated with the pad, if available.
+    let location: LocationResponse?
+
+    /// Coding keys to map the structure to JSON keys during encoding and decoding.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case latitude
+        case longitude
+        case location
+    }
+}

--- a/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/RocketConfigurationResponse.swift
+++ b/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/RocketConfigurationResponse.swift
@@ -1,0 +1,16 @@
+/// The response data for the rocket configuration information.
+struct RocketConfigurationResponse: Codable {
+    /// The unique identifier for the rocket configuration.
+    let id: Int
+    /// The name of the rocket configuration.
+    let name: String
+    /// The URL for the image of the rocket configuration, if available.
+    let imageURL: String?
+
+    /// Coding keys to map the structure to JSON keys during encoding and decoding.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case imageURL = "image_url"
+    }
+}

--- a/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/RocketResponse.swift
+++ b/SpaceLaunches/Data/Network/LaunchLibrary2/Entities/RocketResponse.swift
@@ -1,0 +1,13 @@
+/// The response data for the rocket information.
+struct RocketResponse: Codable {
+    /// The unique identifier for the rocket.
+    let id: Int
+    /// The rocket's configuration details.
+    let configuration: RocketConfigurationResponse
+
+    /// Coding keys to map the structure to JSON keys during encoding and decoding.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case configuration
+    }
+}


### PR DESCRIPTION
## What?
Added structures for decoding responses from the LaunchLibrary2 API:
- `LaunchListResponse`
- `LaunchResponse`
- `LaunchStatusResponse`
- `LaunchServiceProviderResponse`
- `RocketResponse`
- `RocketConfigurationResponse`
- `MissionResponse`
- `OrbitResponse`
- `AgencyResponse`
- `PadResponse`
- `LocationResponse`